### PR TITLE
Enable hotreloading for assets pipeline

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+  config.assets.compile = true
+  config.assets.digest = false
 
   config.active_storage.service = :cloudinary
 


### PR DESCRIPTION
## Context
Currently, if we make changes to the JS files, we always have to `rails assets:clobber assets:precompile` to see the changes. That's actually why @geo-179 cannot see the bugs that @mugz55 and I see 👇 about the stimulus controller. Because the change that Gio made that may have caused the issue is not live on his side.
<img width="1062" alt="Screen Shot 2023-06-09 at 11 55 07" src="https://github.com/geo-179/utopie/assets/43337020/2b25fa1f-b560-498d-ab8f-6f1ab6ef33a6">

## Solution
To resolve this, we need to enable hot reloading again for the assets - that means, compile lively, instead of precompile. In this PR, I changed the following:
- changed the `assets.config.compile` to `true` in development environment so [it lively compiles](https://guides.rubyonrails.org/asset_pipeline.html#live-compilation) every time.